### PR TITLE
extended support of DCF77 modules

### DIFF
--- a/Funkuhr.h
+++ b/Funkuhr.h
@@ -42,7 +42,7 @@ struct Dcf77Time {
 
 class Funkuhr {
 	public:
-  		Funkuhr();
+  		Funkuhr(uint8_t intNumber = 0, uint8_t dcf77Pin = 2, uint8_t blinkPin = 13, bool invertedSignal = false);
 		void init();
 		void getTime(Dcf77Time& dt);
 		uint8_t synced();

--- a/examples/Example/Example.pde
+++ b/examples/Example/Example.pde
@@ -3,7 +3,7 @@
  */
 #include "Funkuhr.h"
 
-Funkuhr dcf;
+Funkuhr dcf(0, 2, 13, false);
 struct Dcf77Time dt = { 0 };
 
 uint8_t curSec;
@@ -73,7 +73,6 @@ void dumpTime(void)
 void setup(void) 
 {
 	Serial.begin(9600);
-	//lcd.begin(20, 4);
 	dcf.init();
 }
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -6,13 +6,13 @@
 # Datatypes (KEYWORD1)
 ####################################
 
-Funkuhr		KEYWORD1
-
+Funkuhr	KEYWORD1
+Dcf77Time	KEYWORD1
 
 ####################################
 # Methods and Functions (KEYWORD2)
 ####################################
 
-init		KEYWORD2
-getTime		KEYWORD2
-synced		KEYWORD2
+init	KEYWORD2
+getTime	KEYWORD2
+synced	KEYWORD2


### PR DESCRIPTION
Hello,

I'm using a DCF77 module sold by Conrad and I've made some modifications for using it with the Funkuhr library. It is now possible to configure the DCF77 pin and the state of the DCF77 signal (inverted or not inverted).

I've also moved the example sketch to make it visible by the Arduino IDE. In keywords.txt file, I've replaced spaces by tabulations for having syntax highlight.

Regards,
Julien
